### PR TITLE
Fix bad regex (issue #119)

### DIFF
--- a/Converter/SemverConverter.php
+++ b/Converter/SemverConverter.php
@@ -57,7 +57,7 @@ class SemverConverter implements VersionConverterInterface
             $range = str_replace($character.' ', $character, $range);
         }
 
-        if (preg_match_all('/[v|V](\d+)/', $range, $matches, PREG_SET_ORDER)) {
+        if (preg_match_all('/(?:[vV])?(\d+)/', $range, $matches, PREG_SET_ORDER)) {
             foreach ($matches as $match) {
                 $range = str_replace($match[0], $match[1], $range);
             }


### PR DESCRIPTION
There are some issues with the regex that this commit fixes:

* The first one is that `[v|V]` is already a range, so there is no need for the `|`.
* The current regex is actually expecting either `v` or `V` in the version, but that is not required, so we make the entire `[vV]` optional, by wrapping it into a `()?`.
* Because a missing `v` or `V` will still match as an empty match (`""`), we need to exclude the result, so we make the group optional: `?:`