### PR TITLE
Tweak the 'vV' replacing logic and mimic Bower and NPM behavior

### DIFF
--- a/Converter/SemverConverter.php
+++ b/Converter/SemverConverter.php
@@ -40,6 +40,7 @@ class SemverConverter implements VersionConverterInterface
     public function convertRange($range)
     {
         $range = $this->cleanRange(strtolower($range));
+        $range = preg_replace('/(?<!\S)[vV]?\d+(?:\.\d+)?(?!\S)/', '${0}.*', $range);
 
         return $this->matchRange($range);
     }

--- a/Converter/SemverConverter.php
+++ b/Converter/SemverConverter.php
@@ -57,11 +57,7 @@ class SemverConverter implements VersionConverterInterface
             $range = str_replace($character.' ', $character, $range);
         }
 
-        if (preg_match_all('/(?:[vV])?(\d+)/', $range, $matches, PREG_SET_ORDER)) {
-            foreach ($matches as $match) {
-                $range = str_replace($match[0], $match[1], $range);
-            }
-        }
+        $range = preg_replace('/(?:[vV])(\d+)/', '${1}', $range);
 
         return str_replace(' ||', '||', $range);
     }


### PR DESCRIPTION
Those 2 commits greatly improve this plugin. I'm pasting here the commit messages as they describe pretty well what each commit does:

### commit 1

Currently the 'vV' chars are replaced with str_replace,
after a preg_match. Because of how str_replace works, this could
lead to some potential bugs. Replace with a single preg_replace
that will handle the job in exactly the same way.

As a side bonus, we're getting rid of a loop, which could speed
up things a little bit.

### commit 2

Mimic the behavior of NPM and Bower when comparing versions
constructed by 1 or 2 groups of numbers.

Versions as "1", "7.9", "v4" and "v98.2" are perfectly valid
and both Bower and NPM expand those to, accordingly, "1.\*",
"7.9.\*", "v4.\*" and "v98.2.\*". Until now this plugin
failed at doing so, which causes quite some failures when
trying to install packages that use that syntax (npmconf,
just to name one).

This commit fixes that by adding a single regex replace
that matches 1 or 2 groups of numbers and appends an ".*".
Also, the regex keeps in mind that other type of versions,
such as "~2" or ">=4.5" don't need to be expanded.

Also note that this fix will not break current unit
tests.