### PR TITLE
Npm repo url strip 'git+'

### DIFF
--- a/Repository/NpmRepository.php
+++ b/Repository/NpmRepository.php
@@ -157,6 +157,10 @@ class NpmRepository extends AbstractAssetsRepository
             throw $ex;
         }
 
-        return (string) $data['repository']['url'];
+        $url = (string) $data['repository']['url'];
+        if (strpos($url, "git+https") === 0) {
+            return substr($url, 4) ;
+        }
+        return $url;
     }
 }


### PR DESCRIPTION
This PR fixes issue #112 
I'm sorry for not adding a test but the code was a bit to confusing for me to (quickly) add a test.

Btw. Great plugin!