### PR TITLE
Fix Deprecation Warning for VersionParser::parseLinks()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
 matrix:
     include:
         - php: 5.6
-          env: COMPOSER_VERSION=1.0.0-alpha10
+          env: COMPOSER_VERSION=dev-master#42bfe9c56adb555cc08e9ce2d32f6763ff75ae5d
 
     allow_failures:
         - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,12 @@ php:
     - hhvm
 
 env:
-    - COMPOSER_VERSION='~1.0@dev'
+    - COMPOSER_VERSION=~1.0@dev
 
 matrix:
     include:
         - php: 5.6
-          env: COMPOSER_VERSION='v1.0.0-alpha10'
+          env: COMPOSER_VERSION=1.0.0-alpha10
 
     allow_failures:
         - php: hhvm
@@ -21,7 +21,7 @@ matrix:
 before_script:
     - composer self-update
     - composer install
-    - composer require composer/composer:${COMPOSER_VERSION}
+    - composer require --dev composer/composer:${COMPOSER_VERSION}
     - composer require --dev --no-update phpunit/phpunit:@stable phpunit/php-code-coverage:@stable satooshi/php-coveralls:@dev
     - composer update phpunit/php-code-coverage satooshi/php-coveralls
     - mkdir -p ./build/logs

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,8 @@ matrix:
 before_script:
     - composer self-update
     - composer install
-    - composer require --dev composer/composer:${COMPOSER_VERSION}
-    - composer require --dev --no-update phpunit/phpunit:@stable phpunit/php-code-coverage:@stable satooshi/php-coveralls:@dev
-    - composer update phpunit/php-code-coverage satooshi/php-coveralls
+    - composer require --dev --no-update phpunit/phpunit:@stable phpunit/php-code-coverage:@stable satooshi/php-coveralls:@dev composer/composer:${COMPOSER_VERSION}
+    - composer update phpunit/php-code-coverage satooshi/php-coveralls composer/composer
     - mkdir -p ./build/logs
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,22 +8,23 @@ php:
     - hhvm
 
 env:
-    - COMPOSER_VERSION=''
+    - COMPOSER_VERSION='~1.0@dev'
 
 matrix:
     include:
         - php: 5.6
-          env: COMPOSER_VERSION='--version=1.0.0-alpha10'
+          env: COMPOSER_VERSION='v1.0.0-alpha10'
 
     allow_failures:
         - php: hhvm
 
 before_script:
+    - composer self-update
+    - composer install
+    - composer require composer/composer:${COMPOSER_VERSION}
+    - composer require --dev --no-update phpunit/phpunit:@stable phpunit/php-code-coverage:@stable satooshi/php-coveralls:@dev
+    - composer update phpunit/php-code-coverage satooshi/php-coveralls
     - mkdir -p ./build/logs
-    - curl -sS https://getcomposer.org/installer | php -- --install-dir=./build --filename=composer ${COMPOSER_VERSION}
-    - ./build/composer install
-    - ./build/composer require --dev --no-update phpunit/phpunit:@stable phpunit/php-code-coverage:@stable satooshi/php-coveralls:@dev
-    - ./build/composer update phpunit/php-code-coverage satooshi/php-coveralls
 
 script:
     - ./vendor/bin/phpunit --coverage-clover ./build/logs/clover.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,23 @@ php:
     - 5.6
     - hhvm
 
+env:
+    - COMPOSER_VERSION=''
+
 matrix:
+    include:
+        - php: 5.6
+          env: COMPOSER_VERSION='--version=1.0.0-alpha10'
+
     allow_failures:
         - php: hhvm
 
 before_script:
-    - composer self-update
-    - composer install
-    - composer require --dev --no-update phpunit/phpunit:@stable phpunit/php-code-coverage:@stable satooshi/php-coveralls:@dev
-    - composer update phpunit/php-code-coverage satooshi/php-coveralls
     - mkdir -p ./build/logs
+    - curl -sS https://getcomposer.org/installer | php -- --install-dir=./build --filename=composer ${COMPOSER_VERSION}
+    - ./build/composer install
+    - ./build/composer require --dev --no-update phpunit/phpunit:@stable phpunit/php-code-coverage:@stable satooshi/php-coveralls:@dev
+    - ./build/composer update phpunit/php-code-coverage satooshi/php-coveralls
 
 script:
     - ./vendor/bin/phpunit --coverage-clover ./build/logs/clover.xml

--- a/Repository/VcsPackageFilter.php
+++ b/Repository/VcsPackageFilter.php
@@ -276,7 +276,11 @@ class VcsPackageFilter
         foreach ($this->installedRepository->getPackages() as $package) {
             $operator = $this->getFilterOperator($package);
             /* @var Link $link */
-            $link = current($this->arrayLoader->parseLinks($this->package->getName(), $this->package->getVersion(), 'installed', array($package->getName() => $operator.$package->getPrettyVersion())));
+            if (method_exists($this->arrayLoader, 'parseLinks')) {
+                $link = current($this->arrayLoader->parseLinks($this->package->getName(), $this->package->getVersion(), 'installed', array($package->getName() => $operator.$package->getPrettyVersion())));
+            } else {
+                $link = current($this->versionParser->parseLinks($this->package->getName(), $this->package->getVersion(), 'installed', array($package->getName() => $operator.$package->getPrettyVersion())));
+            }
             $link = $this->includeRootConstraint($package, $link);
 
             $this->requires[$package->getName()] = $link;

--- a/Repository/VcsPackageFilter.php
+++ b/Repository/VcsPackageFilter.php
@@ -17,6 +17,7 @@ use Composer\Package\Package;
 use Composer\Package\PackageInterface;
 use Composer\Package\RootPackageInterface;
 use Composer\Package\LinkConstraint\MultiConstraint;
+use Composer\Package\Loader\ArrayLoader;
 use Composer\Repository\InstalledFilesystemRepository;
 use Fxp\Composer\AssetPlugin\Package\Version\VersionParser;
 use Fxp\Composer\AssetPlugin\Type\AssetTypeInterface;
@@ -50,6 +51,11 @@ class VcsPackageFilter
     protected $versionParser;
 
     /**
+     * @var ArrayLoader
+     */
+    protected $arrayLoader;
+
+    /**
      * @var bool
      */
     protected $enabled;
@@ -72,6 +78,7 @@ class VcsPackageFilter
         $this->installationManager = $installationManager;
         $this->installedRepository = $installedRepository;
         $this->versionParser = new VersionParser();
+        $this->arrayLoader = new ArrayLoader();
         $this->enabled = true;
 
         $this->initialize();
@@ -269,7 +276,7 @@ class VcsPackageFilter
         foreach ($this->installedRepository->getPackages() as $package) {
             $operator = $this->getFilterOperator($package);
             /* @var Link $link */
-            $link = current($this->versionParser->parseLinks($this->package->getName(), $this->package->getVersion(), 'installed', array($package->getName() => $operator.$package->getPrettyVersion())));
+            $link = current($this->arrayLoader->parseLinks($this->package->getName(), $this->package->getVersion(), 'installed', array($package->getName() => $operator.$package->getPrettyVersion())));
             $link = $this->includeRootConstraint($package, $link);
 
             $this->requires[$package->getName()] = $link;

--- a/Tests/Repository/VcsPackageFilterTest.php
+++ b/Tests/Repository/VcsPackageFilterTest.php
@@ -552,8 +552,14 @@ class VcsPackageFilterTest extends \PHPUnit_Framework_TestCase
      */
     protected function init(array $requires = array(), $minimumStability = 'stable', array $extra = array())
     {
-        $parser = new ArrayLoader();
-        $linkRequires = $parser->parseLinks('__ROOT__', '1.0.0', 'requires', $requires);
+        if (method_exists('Composer\Package\Loader\ArrayLoader', 'parseLinks')) {
+            $parser = new ArrayLoader();
+            $linkRequires = $parser->parseLinks('__ROOT__', '1.0.0', 'requires', $requires);
+        } else {
+            $parser = new VersionParser();
+            $linkRequires = $parser->parseLinks('__ROOT__', '1.0.0', 'requires', $requires);
+        }
+
         $stabilityFlags = $this->findStabilityFlags($requires);
 
         $this->package->expects($this->any())

--- a/Tests/Repository/VcsPackageFilterTest.php
+++ b/Tests/Repository/VcsPackageFilterTest.php
@@ -12,6 +12,7 @@
 namespace Fxp\Composer\AssetPlugin\Tests\Repository;
 
 use Composer\Installer\InstallationManager;
+use Composer\Package\Loader\ArrayLoader;
 use Composer\Package\Package;
 use Composer\Package\RootPackageInterface;
 use Composer\Repository\InstalledFilesystemRepository;
@@ -551,7 +552,7 @@ class VcsPackageFilterTest extends \PHPUnit_Framework_TestCase
      */
     protected function init(array $requires = array(), $minimumStability = 'stable', array $extra = array())
     {
-        $parser = new VersionParser();
+        $parser = new ArrayLoader();
         $linkRequires = $parser->parseLinks('__ROOT__', '1.0.0', 'requires', $requires);
         $stabilityFlags = $this->findStabilityFlags($requires);
 

--- a/composer.lock
+++ b/composer.lock
@@ -13,12 +13,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "c43a39f7334ae3df968cd36a6eff0436bea0da75"
+                "reference": "92faf1c7a83a73794fb914a990be435e1df373ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/c43a39f7334ae3df968cd36a6eff0436bea0da75",
-                "reference": "c43a39f7334ae3df968cd36a6eff0436bea0da75",
+                "url": "https://api.github.com/repos/composer/composer/zipball/92faf1c7a83a73794fb914a990be435e1df373ca",
+                "reference": "92faf1c7a83a73794fb914a990be435e1df373ca",
                 "shasum": ""
             },
             "require": {
@@ -76,20 +76,20 @@
                 "dependency",
                 "package"
             ],
-            "time": "2015-06-22 12:25:03"
+            "time": "2015-07-14 12:37:15"
         },
         {
             "name": "justinrainbow/json-schema",
-            "version": "1.4.2",
+            "version": "1.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/justinrainbow/json-schema.git",
-                "reference": "7dfe4f1db8a62be3dd35710efce663537d515653"
+                "reference": "8dc9b9d85ab639ca60ab4608b34c1279d6ae7bce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/7dfe4f1db8a62be3dd35710efce663537d515653",
-                "reference": "7dfe4f1db8a62be3dd35710efce663537d515653",
+                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/8dc9b9d85ab639ca60ab4608b34c1279d6ae7bce",
+                "reference": "8dc9b9d85ab639ca60ab4608b34c1279d6ae7bce",
                 "shasum": ""
             },
             "require": {
@@ -142,7 +142,7 @@
                 "json",
                 "schema"
             ],
-            "time": "2015-06-14 20:01:28"
+            "time": "2015-07-14 16:29:50"
         },
         {
             "name": "seld/cli-prompt",
@@ -284,16 +284,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v2.7.1",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Console.git",
-                "reference": "564398bc1f33faf92fc2ec86859983d30eb81806"
+                "reference": "8cf484449130cabfd98dcb4694ca9945802a21ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/564398bc1f33faf92fc2ec86859983d30eb81806",
-                "reference": "564398bc1f33faf92fc2ec86859983d30eb81806",
+                "url": "https://api.github.com/repos/symfony/Console/zipball/8cf484449130cabfd98dcb4694ca9945802a21ed",
+                "reference": "8cf484449130cabfd98dcb4694ca9945802a21ed",
                 "shasum": ""
             },
             "require": {
@@ -337,20 +337,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2015-06-10 15:30:22"
+            "time": "2015-07-09 16:07:40"
         },
         {
             "name": "symfony/finder",
-            "version": "v2.7.1",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Finder.git",
-                "reference": "c13a40d638aeede1e8400f8c956c7f9246c05f75"
+                "reference": "ae0f363277485094edc04c9f3cbe595b183b78e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Finder/zipball/c13a40d638aeede1e8400f8c956c7f9246c05f75",
-                "reference": "c13a40d638aeede1e8400f8c956c7f9246c05f75",
+                "url": "https://api.github.com/repos/symfony/Finder/zipball/ae0f363277485094edc04c9f3cbe595b183b78e4",
+                "reference": "ae0f363277485094edc04c9f3cbe595b183b78e4",
                 "shasum": ""
             },
             "require": {
@@ -386,20 +386,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2015-06-04 20:11:48"
+            "time": "2015-07-09 16:07:40"
         },
         {
             "name": "symfony/process",
-            "version": "v2.7.1",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Process.git",
-                "reference": "552d8efdc80980cbcca50b28d626ac8e36e3cdd1"
+                "reference": "48aeb0e48600321c272955132d7606ab0a49adb3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Process/zipball/552d8efdc80980cbcca50b28d626ac8e36e3cdd1",
-                "reference": "552d8efdc80980cbcca50b28d626ac8e36e3cdd1",
+                "url": "https://api.github.com/repos/symfony/Process/zipball/48aeb0e48600321c272955132d7606ab0a49adb3",
+                "reference": "48aeb0e48600321c272955132d7606ab0a49adb3",
                 "shasum": ""
             },
             "require": {
@@ -435,7 +435,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2015-06-08 09:37:21"
+            "time": "2015-07-01 11:25:50"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
Replace call to Composer\Package\Version\VersionParser::parseLinks()
with call to Composer\Package\Loader\ArrayLoader::parseLinks() as
suggested by the deprecation warning.

Update composer lock file so that the version of composer specified
includes the depreciation warning and newly added replacement method.