### PR TITLE
Add feature to override main files for assets

### DIFF
--- a/Installer/AssetInstaller.php
+++ b/Installer/AssetInstaller.php
@@ -84,7 +84,7 @@ class AssetInstaller extends LibraryInstaller
      */
     protected function updateCode(PackageInterface $initial, PackageInterface $target)
     {
-        $package = AssetPlugin::addMainFiles($this->composer, $package);
+        $target = AssetPlugin::addMainFiles($this->composer, $target);
 
         parent::updateCode($initial, $target);
 

--- a/Installer/AssetInstaller.php
+++ b/Installer/AssetInstaller.php
@@ -17,6 +17,7 @@ use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
 use Composer\Util\Filesystem;
 use Fxp\Composer\AssetPlugin\Type\AssetTypeInterface;
+use Fxp\Composer\AssetPlugin\Util\AssetPlugin;
 
 /**
  * Installer for asset packages.
@@ -71,6 +72,8 @@ class AssetInstaller extends LibraryInstaller
      */
     protected function installCode(PackageInterface $package)
     {
+        $package = AssetPlugin::addMainFiles($this->composer, $package);
+
         parent::installCode($package);
 
         $this->deleteIgnoredFiles($package);
@@ -81,6 +84,8 @@ class AssetInstaller extends LibraryInstaller
      */
     protected function updateCode(PackageInterface $initial, PackageInterface $target)
     {
+        $package = AssetPlugin::addMainFiles($this->composer, $package);
+
         parent::updateCode($initial, $target);
 
         $this->deleteIgnoredFiles($target);

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -354,6 +354,31 @@ Package. To do this, you can use the script helper
 }
 ```
 
+### Override the main files for Bower
+
+The bower.json specification allows packages to define entry-point files
+which can later be processed with taskrunners or build scripts. Some Bower
+plugins like main-bower-files, wiredep and asset-builder have a feature to
+override the package main files in the project configuration file.
+
+You can do the same with composer-asset-plugin, just add a section
+`asset-main-files` in the root project `composer.json` file with the package
+name and the files you want to mark as main files.
+
+**Example:**
+
+```json
+{
+    "extra": {
+        "asset-main-files": {
+            "acme/other-asset": [
+                "other-asset.js"
+            ]
+        }
+    }
+}
+```
+
 ### Disable the search for an asset registry
 
 If you want to disable the search for an asset registry, you can add an extra

--- a/Resources/doc/schema.md
+++ b/Resources/doc/schema.md
@@ -43,6 +43,12 @@ Options available for the asset registers:
 - **bower-searchable** (bool): The search in the Bower registry may be disabled with this option
                                for the search command.
 
+##### extra.asset-main-files (root-only)
+
+The plugin can override the main file definitions of the Bower packages. To override the file
+definitions specify the packages and their main file array as name/value pairs. For an example
+see the [usage informations](index.md#override-the-main-files-for-bower).
+
 ### Mapping asset file to composer package
 
 ##### NPM mapping

--- a/Tests/Fixtures/IO/MockIO.php
+++ b/Tests/Fixtures/IO/MockIO.php
@@ -62,7 +62,7 @@ class MockIO extends BaseIO
      */
     public function isVeryVerbose()
     {
-        return false;
+        return $this->verbose;
     }
 
     /**

--- a/Tests/Installer/BowerInstallerTest.php
+++ b/Tests/Installer/BowerInstallerTest.php
@@ -213,17 +213,18 @@ class BowerInstallerTest extends TestCase
         );
     }
 
-    public function getAssetMainFiles(){
+    public function getAssetMainFiles()
+    {
         return array(
             array(array()),
             array(array(
-                'asset-main-files'=>array(
-                    'foo-asset/bar'=>array(
+                'asset-main-files' => array(
+                    'foo-asset/bar' => array(
                         'foo',
-                        'bar'
-                    )
-                )
-            ))
+                        'bar',
+                    ),
+                ),
+            )),
         );
     }
 
@@ -449,7 +450,7 @@ class BowerInstallerTest extends TestCase
         $package = new Package('foo-asset/bar', '1.0.0', '1.0.0');
         $package = AssetPlugin::addMainFiles($this->composer, $package);
         $extra = $package->getExtra();
-        if (isset($mainFiles['asset-main-files'])){
+        if (isset($mainFiles['asset-main-files'])) {
             $this->assertEquals($extra['bower-asset-main'], $mainFiles['asset-main-files']['foo-asset/bar']);
         } else {
             $this->assertEquals($extra, array());

--- a/Tests/Installer/BowerInstallerTest.php
+++ b/Tests/Installer/BowerInstallerTest.php
@@ -14,6 +14,7 @@ namespace Fxp\Composer\AssetPlugin\Tests\Installer;
 use Composer\Downloader\DownloadManager;
 use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
+use Composer\Package\Package;
 use Composer\Package\RootPackageInterface;
 use Composer\Repository\InstalledRepositoryInterface;
 use Composer\Util\Filesystem;
@@ -22,6 +23,7 @@ use Composer\Composer;
 use Composer\Config;
 use Fxp\Composer\AssetPlugin\Installer\BowerInstaller;
 use Fxp\Composer\AssetPlugin\Type\AssetTypeInterface;
+use Fxp\Composer\AssetPlugin\Util\AssetPlugin;
 
 /**
  * Tests of bower asset installer.
@@ -208,6 +210,20 @@ class BowerInstallerTest extends TestCase
         return array(
             array(array()),
             array(array('foo', 'bar')),
+        );
+    }
+
+    public function getAssetMainFiles(){
+        return array(
+            array(array()),
+            array(array(
+                'asset-main-files'=>array(
+                    'foo-asset/bar'=>array(
+                        'foo',
+                        'bar'
+                    )
+                )
+            ))
         );
     }
 
@@ -422,6 +438,25 @@ class BowerInstallerTest extends TestCase
     }
 
     /**
+     * @dataProvider getAssetMainFiles
+     */
+    public function testMainFiles(array $mainFiles)
+    {
+        /* @var RootPackageInterface $rootPackage */
+        $rootPackage = $this->createRootPackageMock($mainFiles);
+        $this->composer->setPackage($rootPackage);
+
+        $package = new Package('foo-asset/bar', '1.0.0', '1.0.0');
+        $package = AssetPlugin::addMainFiles($this->composer, $package);
+        $extra = $package->getExtra();
+        if (isset($mainFiles['asset-main-files'])){
+            $this->assertEquals($extra['bower-asset-main'], $mainFiles['asset-main-files']['foo-asset/bar']);
+        } else {
+            $this->assertEquals($extra, array());
+        }
+    }
+
+    /**
      * @param array $ignoreFiles
      *
      * @return PackageInterface|\PHPUnit_Framework_MockObject_MockObject
@@ -443,9 +478,11 @@ class BowerInstallerTest extends TestCase
     }
 
     /**
+     * @param array $mainFiles
+     *
      * @return RootPackageInterface|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected function createRootPackageMock()
+    protected function createRootPackageMock(array $mainFiles = array())
     {
         $package = $this->getMockBuilder('Composer\Package\RootPackageInterface')
             ->setConstructorArgs(array(md5(mt_rand()), '1.0.0.0', '1.0.0'))
@@ -454,7 +491,7 @@ class BowerInstallerTest extends TestCase
         $package
             ->expects($this->any())
             ->method('getExtra')
-            ->will($this->returnValue(array()));
+            ->will($this->returnValue($mainFiles));
 
         return $package;
     }

--- a/Util/AssetPlugin.php
+++ b/Util/AssetPlugin.php
@@ -14,7 +14,7 @@ namespace Fxp\Composer\AssetPlugin\Util;
 use Composer\Composer;
 use Composer\IO\IOInterface;
 use Composer\Repository\RepositoryManager;
-use Composer\Package\PackageInterface;
+use Composer\Package\Package;
 use Fxp\Composer\AssetPlugin\Assets;
 use Fxp\Composer\AssetPlugin\Installer\AssetInstaller;
 use Fxp\Composer\AssetPlugin\Installer\BowerInstaller;
@@ -106,10 +106,10 @@ class AssetPlugin
      * Adds the main file definitions from the root package.
      *
      * @param Composer         $composer
-     * @param PackageInterface $package
+     * @param Package          $package
      * @param string           $section
      */
-    public static function addMainFiles(Composer $composer, PackageInterface $package, $section = 'asset-main-files')
+    public static function addMainFiles(Composer $composer, Package $package, $section = 'asset-main-files')
     {
         $packageExtra = $package->getExtra();
 

--- a/Util/AssetPlugin.php
+++ b/Util/AssetPlugin.php
@@ -111,7 +111,7 @@ class AssetPlugin
      */
     public static function addMainFiles(Composer $composer, PackageInterface $package, $section = 'asset-main-files')
     {
-        if (! in_array('Composer\Package\Package', class_parents($package))) {
+        if (! get_class($package) == 'Composer\Package\Package' && ! in_array('Composer\Package\Package', class_parents($package))) {
             return $package;
         }
 

--- a/Util/AssetPlugin.php
+++ b/Util/AssetPlugin.php
@@ -111,26 +111,24 @@ class AssetPlugin
      */
     public static function addMainFiles(Composer $composer, PackageInterface $package, $section = 'asset-main-files')
     {
-        if (! get_class($package) == 'Composer\Package\Package' && ! in_array('Composer\Package\Package', class_parents($package))) {
-            return $package;
-        }
+        if (get_class($package) == 'Composer\Package\Package' || in_array('Composer\Package\Package', class_parents($package))) {
+            $packageExtra = $package->getExtra();
 
-        $packageExtra = $package->getExtra();
-
-        $extra = $composer->getPackage()->getExtra();
-        if (isset($extra[$section])) {
-            foreach ($extra[$section] as $packageName => $files) {
-                if ($packageName === $package->getName()) {
-                    $packageExtra['bower-asset-main'] = $files;
-                    break;
+            $extra = $composer->getPackage()->getExtra();
+            if (isset($extra[$section])) {
+                foreach ($extra[$section] as $packageName => $files) {
+                    if ($packageName === $package->getName()) {
+                        $packageExtra['bower-asset-main'] = $files;
+                        break;
+                    }
                 }
             }
+            // copied from Repository\AbstractAssetVcsRepository->injectExtraConfig
+            $ref = new \ReflectionClass($package);
+            $met = $ref->getProperty('extra');
+            $met->setAccessible(true);
+            $met->setValue($package, $packageExtra);
         }
-        // copied from Repository\AbstractAssetVcsRepository->injectExtraConfig
-        $ref = new \ReflectionClass($package);
-        $met = $ref->getProperty('extra');
-        $met->setAccessible(true);
-        $met->setValue($package, $packageExtra);
 
         return $package;
     }

--- a/Util/AssetPlugin.php
+++ b/Util/AssetPlugin.php
@@ -111,7 +111,7 @@ class AssetPlugin
      */
     public static function addMainFiles(Composer $composer, PackageInterface $package, $section = 'asset-main-files')
     {
-        if (get_class($package) == 'Composer\Package\Package' || in_array('Composer\Package\Package', class_parents($package))) {
+        if ($package instanceof \Composer\Package\Package) {
             $packageExtra = $package->getExtra();
 
             $extra = $composer->getPackage()->getExtra();
@@ -123,11 +123,7 @@ class AssetPlugin
                     }
                 }
             }
-            // copied from Repository\AbstractAssetVcsRepository->injectExtraConfig
-            $ref = new \ReflectionClass($package);
-            $met = $ref->getProperty('extra');
-            $met->setAccessible(true);
-            $met->setValue($package, $packageExtra);
+            $package->setExtra($packageExtra);
         }
 
         return $package;

--- a/Util/AssetPlugin.php
+++ b/Util/AssetPlugin.php
@@ -14,6 +14,7 @@ namespace Fxp\Composer\AssetPlugin\Util;
 use Composer\Composer;
 use Composer\IO\IOInterface;
 use Composer\Repository\RepositoryManager;
+use Composer\Package\PackageInterface;
 use Fxp\Composer\AssetPlugin\Assets;
 use Fxp\Composer\AssetPlugin\Installer\AssetInstaller;
 use Fxp\Composer\AssetPlugin\Installer\BowerInstaller;
@@ -99,5 +100,29 @@ class AssetPlugin
                 $rm->setRepositoryClass($assetType.'-'.$driverType, $repositoryClass);
             }
         }
+    }
+
+    /**
+     * Adds the main file definitions from the root package.
+     *
+     * @param Composer         $composer
+     * @param PackageInterface $package
+     * @param string           $section
+     */
+    public static function addMainFiles(Composer $composer, PackageInterface $package, $section = 'asset-main-files')
+    {
+        $packageExtra = $package->getExtra();
+
+        $extra = $composer->getPackage()->getExtra();
+        if (isset($extra[$section])) {
+            foreach ($extra[$section] as $packageName => $files) {
+                if ($packageName === $package->getName()) {
+                    $packageExtra['bower-asset-main'] = $files;
+                    break;
+                }
+            }
+        }
+        $package->setExtra($packageExtra);
+        return $package;
     }
 }

--- a/Util/AssetPlugin.php
+++ b/Util/AssetPlugin.php
@@ -14,7 +14,7 @@ namespace Fxp\Composer\AssetPlugin\Util;
 use Composer\Composer;
 use Composer\IO\IOInterface;
 use Composer\Repository\RepositoryManager;
-use Composer\Package\Package;
+use Composer\Package\PackageInterface;
 use Fxp\Composer\AssetPlugin\Assets;
 use Fxp\Composer\AssetPlugin\Installer\AssetInstaller;
 use Fxp\Composer\AssetPlugin\Installer\BowerInstaller;
@@ -106,10 +106,10 @@ class AssetPlugin
      * Adds the main file definitions from the root package.
      *
      * @param Composer         $composer
-     * @param Package          $package
+     * @param PackageInterface $package
      * @param string           $section
      */
-    public static function addMainFiles(Composer $composer, Package $package, $section = 'asset-main-files')
+    public static function addMainFiles(Composer $composer, PackageInterface $package, $section = 'asset-main-files')
     {
         $packageExtra = $package->getExtra();
 
@@ -122,7 +122,12 @@ class AssetPlugin
                 }
             }
         }
-        $package->setExtra($packageExtra);
+        // copied from Repository\AbstractAssetVcsRepository->injectExtraConfig
+        $ref = new \ReflectionClass($package);
+        $met = $ref->getProperty('extra');
+        $met->setAccessible(true);
+        $met->setValue($package, $packageExtra);
+
         return $package;
     }
 }

--- a/Util/AssetPlugin.php
+++ b/Util/AssetPlugin.php
@@ -111,6 +111,10 @@ class AssetPlugin
      */
     public static function addMainFiles(Composer $composer, PackageInterface $package, $section = 'asset-main-files')
     {
+        if (! in_array('Composer\Package\Package', class_parents($package))) {
+            return $package;
+        }
+
         $packageExtra = $package->getExtra();
 
         $extra = $composer->getPackage()->getExtra();


### PR DESCRIPTION
Some Bower plugins like [main-bower-files](https://github.com/ck86/main-bower-files/tree/master#main), [wiredep](https://github.com/taptapship/wiredep/blob/master/readme.md#bower-overrides) and [asset-builder](https://github.com/austinpray/asset-builder/blob/master/help/troubleshooting.md#some-bower-packages-not-being-injected) already have this feature. The syntax for overriding the main files is similar to overriding the ignore files:

```json
"extra": {
  "asset-main-files": {
    "bower-asset/modernizr": [
      "./modernizr.js"
    ],
  }
}
```