### PR TITLE
fixed deprecated MultiConstraint class in VcsPackageFilter #157

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ matrix:
         - php: 5.4
         - php: 5.5
         - php: 5.6
-        - php: 5.6
-          env: COMPOSER_VERSION=dev-master#42bfe9c56adb555cc08e9ce2d32f6763ff75ae5d
         - php: nightly
 
     allow_failures:

--- a/Repository/VcsPackageFilter.php
+++ b/Repository/VcsPackageFilter.php
@@ -16,8 +16,9 @@ use Composer\Package\Link;
 use Composer\Package\Package;
 use Composer\Package\PackageInterface;
 use Composer\Package\RootPackageInterface;
-use Composer\Package\LinkConstraint\MultiConstraint;
 use Composer\Package\Loader\ArrayLoader;
+use Composer\Package\LinkConstraint\MultiConstraint as LinkMultiConstraint;
+use Composer\Semver\Constraint\MultiConstraint;
 use Composer\Repository\InstalledFilesystemRepository;
 use Fxp\Composer\AssetPlugin\Package\Version\VersionParser;
 use Fxp\Composer\AssetPlugin\Type\AssetTypeInterface;
@@ -288,6 +289,23 @@ class VcsPackageFilter
     }
 
     /**
+     * Get current MultiConstraint class based on the composer version.
+     *
+     * @param array $constraints    Array list of constraints
+     * @param bool  $useConjunctive
+     *
+     * @return \Composer\Semver\Constraint\MultiConstraint|\Composer\Package\LinkConstraint\MultiConstraint
+     */
+    private function getMultiConstraintInstance(array $constraints, $useConjunctive)
+    {
+        if (class_exists('\Composer\Semver\Constraint\MultiConstraint')) {
+            return new MultiConstraint($constraints, $useConjunctive);
+        }
+
+        return new LinkMultiConstraint($constraints, $useConjunctive);
+    }
+
+    /**
      * Include the constraint of root dependency version in the constraint
      * of installed package.
      *
@@ -302,7 +320,7 @@ class VcsPackageFilter
             /* @var Link $rLink */
             $rLink = $this->requires[$package->getName()];
             $useConjunctive = FilterUtil::checkExtraOption($this->package, 'asset-optimize-with-conjunctive');
-            $constraint = new MultiConstraint(array($rLink->getConstraint(), $link->getConstraint()), $useConjunctive);
+            $constraint = $this->getMultiConstraintInstance(array($rLink->getConstraint(), $link->getConstraint()), $useConjunctive);
             $link = new Link($rLink->getSource(), $rLink->getTarget(), $constraint, 'installed', $constraint->getPrettyString());
         }
 

--- a/Tests/Repository/VcsPackageFilterTest.php
+++ b/Tests/Repository/VcsPackageFilterTest.php
@@ -552,13 +552,8 @@ class VcsPackageFilterTest extends \PHPUnit_Framework_TestCase
      */
     protected function init(array $requires = array(), $minimumStability = 'stable', array $extra = array())
     {
-        if (method_exists('Composer\Package\Loader\ArrayLoader', 'parseLinks')) {
-            $parser = new ArrayLoader();
-            $linkRequires = $parser->parseLinks('__ROOT__', '1.0.0', 'requires', $requires);
-        } else {
-            $parser = new VersionParser();
-            $linkRequires = $parser->parseLinks('__ROOT__', '1.0.0', 'requires', $requires);
-        }
+        $parser = new ArrayLoader();
+        $linkRequires = $parser->parseLinks('__ROOT__', '1.0.0', 'requires', $requires);
 
         $stabilityFlags = $this->findStabilityFlags($requires);
 


### PR DESCRIPTION
What would be the best approach to guarantee backwards compatibility? I can not relay on Composer\Composer::Version as already mentioned in https://github.com/francoispluchino/composer-asset-plugin/pull/133#issuecomment-121978687