### PR TITLE
implementing getInstallPath as per  suggestion of @Seldaek

### DIFF
--- a/Installer/AssetInstaller.php
+++ b/Installer/AssetInstaller.php
@@ -62,9 +62,11 @@ class AssetInstaller extends LibraryInstaller
     {
         $this->initializeVendorDir();
 
+        $targetDir = $package->getTargetDir();
+
         list(, $name) = explode('/', $package->getPrettyName(), 2);
 
-        return ($this->vendorDir ? $this->vendorDir.'/' : '').$name;
+        return ($this->vendorDir ? $this->vendorDir.'/' : '').$name.($targetDir ? '/'.$targetDir : '');
     }
 
     /**

--- a/Installer/AssetInstaller.php
+++ b/Installer/AssetInstaller.php
@@ -58,13 +58,21 @@ class AssetInstaller extends LibraryInstaller
     /**
      * {@inheritdoc}
      */
-    protected function getPackageBasePath(PackageInterface $package)
+    public function getInstallPath(PackageInterface $package)
     {
         $this->initializeVendorDir();
 
         list(, $name) = explode('/', $package->getPrettyName(), 2);
 
         return ($this->vendorDir ? $this->vendorDir.'/' : '').$name;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getPackageBasePath(PackageInterface $package)
+    {
+        return $this->getInstallPath($package);
     }
 
     /**


### PR DESCRIPTION
getPackageBasePath now only redirecting to getInstallPath

fix for #165 as discussed.

works with current (https://github.com/composer/composer/commit/dbcf8cae1384dfc5acab5ec1d07d43580d326a48) and `composer.lock`ed version (https://github.com/composer/composer/commit/a54f84f05f915c6d42bed94de0cdcb4406a4707b) of composer.