### PR TITLE
add params whatProvides

### DIFF
--- a/Repository/AbstractAssetsRepository.php
+++ b/Repository/AbstractAssetsRepository.php
@@ -121,7 +121,7 @@ abstract class AbstractAssetsRepository extends ComposerRepository
     /**
      * {@inheritdoc}
      */
-    public function whatProvides(Pool $pool, $name)
+    public function whatProvides(Pool $pool, $name, $bypassFilters = false)
     {
         if (null !== $provides = $this->findWhatProvides($name)) {
             return $provides;


### PR DESCRIPTION
```
[ErrorException]
  Declaration of Fxp\Composer\AssetPlugin\Repository\AbstractAssetsRepository::whatProvides() should be compatible with Composer\Repository\ComposerRepository::whatProvides(Composer\DependencyResolver\Pool $pool, $name, $bypassFilters = false)
```
[issues 2661](https://github.com/composer/composer/issues/2661)