### PR TITLE
Fix method implementation

### DIFF
--- a/Repository/AbstractAssetsRepository.php
+++ b/Repository/AbstractAssetsRepository.php
@@ -121,7 +121,7 @@ abstract class AbstractAssetsRepository extends ComposerRepository
     /**
      * {@inheritdoc}
      */
-    public function whatProvides(Pool $pool, $name)
+    public function whatProvides(Pool $pool, $name, $bypassFilters = false)
     {
         if (null !== $provides = $this->findWhatProvides($name)) {
             return $provides;

--- a/Tests/Fixtures/IO/MockIO.php
+++ b/Tests/Fixtures/IO/MockIO.php
@@ -154,6 +154,14 @@ class MockIO extends BaseIO
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function select($question, $choices, $default, $attempts = false, $errorMessage = 'Value "%s" is invalid', $multiselect = false)
+    {
+        return $default;
+    }
+
+    /**
      * Gets the taces.
      *
      * @return array

--- a/Tests/Repository/Vcs/SvnDriverTest.php
+++ b/Tests/Repository/Vcs/SvnDriverTest.php
@@ -36,6 +36,7 @@ class SvnDriverTest extends \PHPUnit_Framework_TestCase
             'config' => array(
                 'home' => sys_get_temp_dir().'/composer-test',
                 'cache-repo-dir' => sys_get_temp_dir().'/composer-test-cache',
+                'secure-http' => false,
             ),
         ));
     }


### PR DESCRIPTION
https://github.com/composer/composer/commit/623c0dcda7a29a06d21e9736527b05ca436d0f4b

In method _ComposerRepository::whatProvides()_ was added a new parameter. 
After _composer self-update_, it began to throw an exceptions
```
[ReflectionException]                                                   
Class Fxp\Composer\AssetPlugin\Repository\NpmRepository does not exist  
                                                                                                                                                                                                              
[ErrorException]                                                                                                                                                                                            
Declaration of Fxp\Composer\AssetPlugin\Repository\AbstractAssetsRepository::whatProvides() should be compatible with Composer\Repository\ComposerRepository::whatProvides(Composer\DependencyResolver\Pool $pool, $name, $bypassFilters = false)
```