### PR TITLE
Prevent fatal str_pos() error in dist parsing.

### DIFF
--- a/Converter/NpmPackageUtil.php
+++ b/Converter/NpmPackageUtil.php
@@ -68,6 +68,9 @@ abstract class NpmPackageUtil
             $value = array();
 
             foreach ($data as $type => $url) {
+                if (!is_string($url)) {
+                  continue;
+                }
                 $httpPrefix = 'http://';
                 if (0 === strpos($url, $httpPrefix)) {
                     $url = 'https://'.substr($url, strlen($httpPrefix));


### PR DESCRIPTION
I'm encountering the following error:

```
Adding VCS repository npm-asset/defined
Adding VCS repository npm-asset/deps-sort
Adding VCS repository npm-asset/domain-browser
Adding VCS repository npm-asset/duplexer2


  [ErrorException]
  strpos() expects parameter 1 to be string, array given


Exception trace:
 () at /Users/matthew.grasmick/Sites/acquia/lightning/vendor/fxp/composer-asset-plugin/Converter/NpmPackageUtil.php:72
 Composer\Util\ErrorHandler::handle() at n/a:n/a
 strpos() at /Users/matthew.grasmick/Sites/acquia/lightning/vendor/fxp/composer-asset-plugin/Converter/NpmPackageUtil.php:72
 Fxp\Composer\AssetPlugin\Converter\NpmPackageUtil::convertDist() at /Users/matthew.grasmick/Sites/acquia/lightning/vendor/fxp/composer-asset-plugin/Converter/NpmPackageConverter.php:53
 Fxp\Composer\AssetPlugin\Converter\NpmPackageConverter->Fxp\Composer\AssetPlugin\Converter\{closure}() at /Users/matthew.grasmick/Sites/acquia/lightning/vendor/fxp/composer-asset-plugin/Converter/PackageUtil.php:162
 Fxp\Composer\AssetPlugin\Converter\PackageUtil::convertArrayKey() at /Users/matthew.grasmick/Sites/acquia/lightning/vendor/fxp/composer-asset-plugin/Converter/AbstractPackageConverter.php:93
 Fxp\Composer\AssetPlugin\Converter\AbstractPackageConverter->convertKey() at /Users/matthew.grasmick/Sites/acquia/lightning/vendor/fxp/composer-asset-plugin/Converter/AbstractPackageConverter.php:66
 Fxp\Composer\AssetPlugin\Converter\AbstractPackageConverter->convertData() at /Users/matthew.grasmick/Sites/acquia/lightning/vendor/fxp/composer-asset-plugin/Converter/AbstractPackageConverter.php:47
 Fxp\Composer\AssetPlugin\Converter\AbstractPackageConverter->convert() at /Users/matthew.grasmick/Sites/acquia/lightning/vendor/fxp/composer-asset-plugin/Repository/NpmRepository.php:132
 Fxp\Composer\AssetPlugin\Repository\NpmRepository->createArrayRepositoryConfig() at /Users/matthew.grasmick/Sites/acquia/lightning/vendor/fxp/composer-asset-plugin/Repository/NpmRepository.php:79
 Fxp\Composer\AssetPlugin\Repository\NpmRepository->createVcsRepositoryConfig() at /Users/matthew.grasmick/Sites/acquia/lightning/vendor/fxp/composer-asset-plugin/Repository/AbstractAssetsRepository.php:136
 Fxp\Composer\AssetPlugin\Repository\AbstractAssetsRepository->whatProvides() at phar:///usr/local/Cellar/composer/1.0.0-alpha8/libexec/composer.phar/src/Composer/DependencyResolver/Pool.php:199
 Composer\DependencyResolver\Pool->computeWhatProvides() at phar:///usr/local/Cellar/composer/1.0.0-alpha8/libexec/composer.phar/src/Composer/DependencyResolver/Pool.php:188
 Composer\DependencyResolver\Pool->whatProvides() at phar:///usr/local/Cellar/composer/1.0.0-alpha8/libexec/composer.phar/src/Composer/DependencyResolver/RuleSetGenerator.php:161
 Composer\DependencyResolver\RuleSetGenerator->whitelistFromPackage() at phar:///usr/local/Cellar/composer/1.0.0-alpha8/libexec/composer.phar/src/Composer/DependencyResolver/RuleSetGenerator.php:273
 Composer\DependencyResolver\RuleSetGenerator->whitelistFromJobs() at phar:///usr/local/Cellar/composer/1.0.0-alpha8/libexec/composer.phar/src/Composer/DependencyResolver/RuleSetGenerator.php:324
 Composer\DependencyResolver\RuleSetGenerator->getRulesFor() at phar:///usr/local/Cellar/composer/1.0.0-alpha8/libexec/composer.phar/src/Composer/DependencyResolver/Solver.php:208
 Composer\DependencyResolver\Solver->solve() at phar:///usr/local/Cellar/composer/1.0.0-alpha8/libexec/composer.phar/src/Composer/Installer.php:510
 Composer\Installer->doInstall() at phar:///usr/local/Cellar/composer/1.0.0-alpha8/libexec/composer.phar/src/Composer/Installer.php:223
 Composer\Installer->run() at phar:///usr/local/Cellar/composer/1.0.0-alpha8/libexec/composer.phar/src/Composer/Command/InstallCommand.php:134
 Composer\Command\InstallCommand->execute() at phar:///usr/local/Cellar/composer/1.0.0-alpha8/libexec/composer.phar/vendor/symfony/console/Command/Command.php:259
 Symfony\Component\Console\Command\Command->run() at phar:///usr/local/Cellar/composer/1.0.0-alpha8/libexec/composer.phar/vendor/symfony/console/Application.php:844
 Symfony\Component\Console\Application->doRunCommand() at phar:///usr/local/Cellar/composer/1.0.0-alpha8/libexec/composer.phar/vendor/symfony/console/Application.php:192
 Symfony\Component\Console\Application->doRun() at phar:///usr/local/Cellar/composer/1.0.0-alpha8/libexec/composer.phar/src/Composer/Console/Application.php:166
 Composer\Console\Application->doRun() at phar:///usr/local/Cellar/composer/1.0.0-alpha8/libexec/composer.phar/vendor/symfony/console/Application.php:123
 Symfony\Component\Console\Application->run() at phar:///usr/local/Cellar/composer/1.0.0-alpha8/libexec/composer.phar/src/Composer/Console/Application.php:99
 Composer\Console\Application->run() at phar:///usr/local/Cellar/composer/1.0.0-alpha8/libexec/composer.phar/bin/composer:43
 require() at /usr/local/Cellar/composer/1.0.0-alpha8/libexec/composer.phar:25

install [--prefer-source] [--prefer-dist] [--dry-run] [--dev] [--no-dev] [--no-plugins] [--no-custom-installers] [--no-autoloader] [--no-scripts] [--no-progress] [-v|vv|vvv|--verbose] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--ignore-platform-reqs] [--] [<packages>]...
```

I expect that an upstream package has malformed data, or else we're just not properly account for all possible data structures. This commit circumvent the problem. It'd be nice to log a warning, but I'm not familiar with the correct composer method for doing so.