### PR TITLE
Convert bower version notation "1.0.0 - 1.3.x"

### DIFF
--- a/Tests/Converter/SemverConverterTest.php
+++ b/Tests/Converter/SemverConverterTest.php
@@ -126,6 +126,8 @@ class SemverConverterTest extends \PHPUnit_Framework_TestCase
             array('~ 1', '~1'),
             array('^ 1.2.3', '>=1.2.3,<2.0.0'),
             array('1.2.3 - 2.3.4', '>=1.2.3,<=2.3.4'),
+            array('1.0.0 - 1.3.x', '>=1.0.0,<1.4.0'),
+            array('1.0 - 1.x', '>=1.0,<2.0'),
             array('>=0.10.x', '>=0.10.0'),
             array('>=0.10.*', '>=0.10.0'),
             array('<=0.10.x', '<=0.10.9999999'),


### PR DESCRIPTION
composer require bower-asset/backbone.marionette
gives error:
Could not parse version constraint <=1.3.x: Invalid version string "1.3.x"

It's dependencies has been updated to:
"backbone": "1.0.0 - 1.3.x",

Solution.
Convert versions in this format properly. Set the version in question to be < and increment the last number before the x by one.
1.0.0 - 1.3.x => >=1.0.0,<1.4.0
1.0 - 1.x => >=1.0,<2.0

Unit tests added and they work.

Issue fix: https://github.com/francoispluchino/composer-asset-plugin/issues/221